### PR TITLE
Fix the final sonarcloud warnings and adjust AnsibleJob status monitoring

### DIFF
--- a/cmd/curator/curator.go
+++ b/cmd/curator/curator.go
@@ -97,7 +97,7 @@ func main() {
 				"\" does not match the cluster ConfigMap override \"" +
 				clusterConfigOverride.Data["clusterName"] + "\""))
 		}
-		utils.RecordJobContainer(config, clusterConfigOverride, jobChoice)
+		utils.RecordHiveJobContainer(config, clusterConfigOverride, jobChoice)
 		providerCredentialPath = clusterConfigOverride.Data["providerCredentialPath"]
 	} else {
 		if providerCredentialPath == "" || !strings.Contains(jobChoice, "applycloudprovider-") {
@@ -131,7 +131,9 @@ func main() {
 	if jobChoice == "import" || strings.Contains(jobChoice, "create-") {
 
 		// Determine kube path for Cluster Template
-		cmNameSpace, ClusterCMTemplate, err = utils.PathSplitterFromEnv(clusterConfigOverride.Data["clusterConfigTemplatePath"])
+		cmNameSpace, ClusterCMTemplate, err = utils.PathSplitterFromEnv(
+			clusterConfigOverride.Data["clusterConfigTemplatePath"])
+
 		utils.CheckError(err)
 
 		// Gets the Cluster Configuration Template, defaults!

--- a/pkg/controller/launcher/job.go
+++ b/pkg/controller/launcher/job.go
@@ -24,7 +24,12 @@ type Launcher struct {
 	jobConfigMap corev1.ConfigMap
 }
 
-func NewLauncher(client kubernetes.Interface, imageTag string, imageUri string, jobConfigMap corev1.ConfigMap) *Launcher {
+func NewLauncher(
+	client kubernetes.Interface,
+	imageTag string,
+	imageUri string,
+	jobConfigMap corev1.ConfigMap) *Launcher {
+
 	return &Launcher{
 		client:       client,
 		imageTag:     imageTag,

--- a/pkg/jobs/create/hive.go
+++ b/pkg/jobs/create/hive.go
@@ -128,7 +128,11 @@ func CreateClusterDeployment(
 	log.Println("Created ClusterDeployment ✓")
 }
 
-func CreateMachinePool(hiveset *hiveclient.Clientset, configMapTemplate *corev1.ConfigMap, configMapOverride *corev1.ConfigMap) {
+func CreateMachinePool(
+	hiveset *hiveclient.Clientset,
+	configMapTemplate *corev1.ConfigMap,
+	configMapOverride *corev1.ConfigMap) {
+
 	log.Println("* Prepare MachinePool")
 	newMachinePool := &hivev1.MachinePool{}
 	//hivev1.newMachinePool is defined with json for unmarshaling

--- a/pkg/jobs/secrets/secrets.go
+++ b/pkg/jobs/secrets/secrets.go
@@ -32,7 +32,9 @@ func GetSecretData(kubeset *kubernetes.Clientset, providerCredentialPath string)
 	secretNamespace, secretName, err := utils.PathSplitterFromEnv(providerCredentialPath)
 	utils.CheckError(err)
 
-	klog.V(2).Info("=> Retrieving  Provider credential namespace \"" + secretNamespace + "\" secret \"" + secretName + "\"")
+	klog.V(2).Info("=> Retrieving  Provider credential namespace \"" + secretNamespace +
+		"\" secret \"" + secretName + "\"")
+
 	secret, err := kubeset.CoreV1().Secrets(secretNamespace).Get(
 		context.TODO(), secretName, v1.GetOptions{})
 
@@ -77,7 +79,9 @@ func CreateAWSSecrets(kubeset *kubernetes.Clientset, cpSecretData map[string]str
 	stringData := map[string]string{
 		"osServicePrincipal.json": string(bytes),
 	}
-	if err := createPatchSecret(kubeset, stringData, clusterName+suffix, clusterName, corev1.SecretTypeOpaque); err != nil {
+	if err := createPatchSecret(kubeset, stringData, clusterName+suffix, clusterName,
+		corev1.SecretTypeOpaque); err != nil {
+
 		return err
 	}
 	return createCommonSecrets(kubeset, cpSecretData, clusterName)
@@ -89,7 +93,9 @@ func CreateGCPSecrets(kubeset *kubernetes.Clientset, cpSecretData map[string]str
 	stringData := map[string]string{
 		"osServiceAccount.json": cpSecretData["gcServiceAccountKey"],
 	}
-	if err := createPatchSecret(kubeset, stringData, clusterName+suffix, clusterName, corev1.SecretTypeOpaque); err != nil {
+	if err := createPatchSecret(kubeset, stringData, clusterName+suffix, clusterName,
+		corev1.SecretTypeOpaque); err != nil {
+
 		return err
 	}
 	return createCommonSecrets(kubeset, cpSecretData, clusterName)
@@ -102,7 +108,9 @@ func CreateAzureSecrets(kubeset *kubernetes.Clientset, cpSecretData map[string]s
 		"aws_access_key_id":     cpSecretData["awsAccessKeyID"],
 		"aws_secret_access_key": cpSecretData["awsSecretAccessKeyID"],
 	}
-	if err := createPatchSecret(kubeset, stringData, clusterName+suffix, clusterName, corev1.SecretTypeOpaque); err != nil {
+	if err := createPatchSecret(kubeset, stringData, clusterName+suffix, clusterName,
+		corev1.SecretTypeOpaque); err != nil {
+
 		return err
 	}
 	return createCommonSecrets(kubeset, cpSecretData, clusterName)

--- a/pkg/jobs/utils/helpers.go
+++ b/pkg/jobs/utils/helpers.go
@@ -169,10 +169,17 @@ func MonitorDeployStatus(config *rest.Config, clusterName string) error {
 	}
 	return nil
 }
+func RecordAnsibleJob(config *rest.Config, configMap *corev1.ConfigMap, containerName string) {
+	recordJobContainer(config, configMap, containerName, "current-ansible-job")
+}
 
-func RecordJobContainer(config *rest.Config, configMap *corev1.ConfigMap, containerName string) {
+func RecordHiveJobContainer(config *rest.Config, configMap *corev1.ConfigMap, containerName string) {
+	recordJobContainer(config, configMap, containerName, "current-hive-job")
+}
+
+func recordJobContainer(config *rest.Config, configMap *corev1.ConfigMap, containerName string, cmKey string) {
 	kubeset, _ := kubernetes.NewForConfig(config)
-	configMap.Data["curator-job-container"] = containerName
+	configMap.Data[cmKey] = containerName
 	_, err := kubeset.CoreV1().ConfigMaps(configMap.Namespace).Update(context.TODO(), configMap, v1.UpdateOptions{})
 	if err != nil {
 		klog.Warning(err)


### PR DESCRIPTION
Signed off by: Joshua Packer

* Fix a number of line length warning from Sonarcloud
* Remove a 4+ loop/if depth section in AnsibleJob monitoring
* Start to track the AnsibleJob namespacedName in the ConfigMap for the Console to use.

/cc @leena-jawale @hanqiuzh 