### PR TITLE
ManagedClusterInfos monitoring

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -64,6 +64,7 @@ func WatchManagedCluster(config *rest.Config) {
 				for i := 5; i < 60; i = i * 2 { //40s wait
 					if cm, err := findJobConfigMap(kubeset, mc); err == nil {
 						if cm.Data["curator-job"] == "" {
+							//err := rbac.ApplyRBAC(kubeset, mc.Name)
 							err := rbac.ApplyRBAC(kubeset, mc.Name)
 							if err := utils.LogError(err); err != nil {
 								break
@@ -119,7 +120,7 @@ func findJobConfigMap(kubeset *kubernetes.Clientset, mc *mcv1.ManagedCluster) (*
 
 func main() {
 
-	utils.InitKlog()
+	utils.InitKlog(utils.LogVerbosity)
 
 	ctx := context.TODO()
 	// Become the leader before proceeding

--- a/cmd/curator/curator.go
+++ b/cmd/curator/curator.go
@@ -11,7 +11,6 @@ import (
 
 	"k8s.io/klog/v2"
 
-	managedclusterclient "github.com/open-cluster-management/api/client/cluster/clientset/versioned"
 	"github.com/open-cluster-management/cluster-curator-controller/pkg/jobs/ansible"
 	"github.com/open-cluster-management/cluster-curator-controller/pkg/jobs/hive"
 	"github.com/open-cluster-management/cluster-curator-controller/pkg/jobs/importer"
@@ -25,9 +24,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const LogFlag = "v"
-const LogVerbosity = "2"
-
 /* Uses the following environment variables:
  * ./curator applycloudprovider
  *    export CLUSTER_NAME=                  # The name of the cluster
@@ -37,7 +33,7 @@ func main() {
 	var err error
 	var clusterName = os.Getenv("CLUSTER_NAME")
 
-	utils.InitKlog()
+	utils.InitKlog(utils.LogVerbosity)
 
 	if clusterName == "" {
 		data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
@@ -131,10 +127,10 @@ func main() {
 	}
 	// Create a client for the manageclusterV1 CustomResourceDefinitions
 	if jobChoice == "monitor-import" {
-		mcset, err := managedclusterclient.NewForConfig(config)
+		dynclient, err := dynamic.NewForConfig(config)
 		utils.CheckError(err)
 
-		utils.CheckError(importer.MonitorImport(mcset, clusterName))
+		utils.CheckError(importer.MonitorMCInfoImport(dynclient, clusterName))
 	}
 
 	if jobChoice == "ansiblejob" {

--- a/deploy/controller/clusterrole.yaml
+++ b/deploy/controller/clusterrole.yaml
@@ -4,25 +4,39 @@ kind: ClusterRole
 metadata:
   name: cluster-curator
 rules:
+
+# New Rules added to ClusterInstaller
+- apiGroups: ["tower.ansible.com","batch",""]
+  resources: ["ansiblejobs","jobs","serviceaccounts",]
+  verbs: ["create","get"]
+
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles","rolebindings"]
+  verbs: ["create","get"]
+
+- apiGroups: ["", "hive.openshift.io"]
+  resources: ["configmaps", "clusterdeployments"]
+  verbs: ["patch"]
+
+- apiGroups: ["internal.open-cluster-management.io"]
+  resources: ["managedclusterinfos"]
+  verbs: ["get"]
+
+# Specific to the controller only
 - apiGroups: ["cluster.open-cluster-management.io"] 
   resources: ["managedclusters"]
   verbs: ["watch","list"]
-- apiGroups: ["batch","","rbac.authorization.k8s.io"] 
-  resources: ["jobs","serviceaccounts","roles","rolebindings"]
-  verbs: ["create","get"]
-- apiGroups: [""] 
-  resources: ["configmaps","serviceaccounts"]
-  verbs: ["list","get"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["update"]
-# To grant the role, you must have the role
-- apiGroups: ["tower.ansible.com", "", "hive.openshift.io"]
-  resources: ["ansiblejobs", "secrets", "clusterdeployments", "machinepools","configmaps"]
-  verbs: ["create"]
-- apiGroups: ["", "hive.openshift.io"]
-  resources: ["clusterdeployments", "secrets", "configmaps"]
-  verbs: ["patch"]
-- apiGroups: ["", "batch", "hive.openshift.io", "tower.ansible.com"]
-  resources: ["jobs", "clusterdeployments", "ansiblejobs","pods"]
-  verbs: ["get"]
+
+# Existing rules in Role cluster-installer
+#- apiGroups: ["",] 
+#  resources: ["secrets", "configmaps"]
+#  verbs: ["create","delete","get","list","update"]
+#- apiGroups: ["hive.openshift.io"] 
+#  resources: ["dnszones"]
+#  verbs: ["get"]
+#- apiGroups: ["hive.openshift.io"] 
+#  resources: ["clusterdeployments","clusterdeployments/finalizers","clusterdeployments/status"]
+#  verbs: ["get","update"]
+#- apiGroups: ["hive.openshift.io"] 
+#  resources: ["clusterprovisions","clusterprovisions/finalizers","clusterprovisions/status"]
+#  verbs: ["get","list","update","watch"]

--- a/pkg/controller/launcher/job.go
+++ b/pkg/controller/launcher/job.go
@@ -37,7 +37,7 @@ func NewLauncher(
 
 func getBatchJob(configMapName string, imageUri string) *batchv1.Job {
 
-	var flags = []string{"--v", "2"}
+	var ttlf int32 = 3600
 
 	newJob := &batchv1.Job{
 		ObjectMeta: v1.ObjectMeta{
@@ -54,7 +54,8 @@ func getBatchJob(configMapName string, imageUri string) *batchv1.Job {
 			},
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit: new(int32),
+			BackoffLimit:            new(int32),
+			TTLSecondsAfterFinished: &ttlf,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "cluster-installer",
@@ -63,7 +64,7 @@ func getBatchJob(configMapName string, imageUri string) *batchv1.Job {
 						corev1.Container{
 							Name:            "applycloudprovider-ansible",
 							Image:           imageUri,
-							Command:         append([]string{CurCmd, "applycloudprovider-ansible"}, flags...),
+							Command:         append([]string{CurCmd, "applycloudprovider-ansible"}),
 							ImagePullPolicy: corev1.PullAlways,
 							Env: []corev1.EnvVar{
 								corev1.EnvVar{
@@ -75,7 +76,7 @@ func getBatchJob(configMapName string, imageUri string) *batchv1.Job {
 						corev1.Container{
 							Name:            "prehook-ansiblejob",
 							Image:           imageUri,
-							Command:         append([]string{CurCmd, "ansiblejob"}, flags...),
+							Command:         append([]string{CurCmd, "ansiblejob"}),
 							ImagePullPolicy: corev1.PullAlways,
 							Env: []corev1.EnvVar{
 								corev1.EnvVar{
@@ -87,19 +88,19 @@ func getBatchJob(configMapName string, imageUri string) *batchv1.Job {
 						corev1.Container{
 							Name:            "activate-and-monitor",
 							Image:           imageUri,
-							Command:         append([]string{CurCmd, "activate-and-monitor"}, flags...),
+							Command:         append([]string{CurCmd, "activate-and-monitor"}),
 							ImagePullPolicy: corev1.PullAlways,
 						},
-						/*corev1.Container{
+						corev1.Container{
 							Name:            "monitor-import",
 							Image:           imageUri,
-							Command:         append([]string{CurCmd, "monitor-import"}, flags...),
+							Command:         append([]string{CurCmd, "monitor-import"}),
 							ImagePullPolicy: corev1.PullAlways,
-						},*/
+						},
 						corev1.Container{
 							Name:            "posthook-ansiblejob",
 							Image:           imageUri,
-							Command:         append([]string{CurCmd, "ansiblejob"}, flags...),
+							Command:         append([]string{CurCmd, "ansiblejob"}),
 							ImagePullPolicy: corev1.PullAlways,
 							Env: []corev1.EnvVar{
 								corev1.EnvVar{

--- a/pkg/controller/launcher/job_test.go
+++ b/pkg/controller/launcher/job_test.go
@@ -26,7 +26,7 @@ func TestGetBatchJobImageSHA(t *testing.T) {
 	t.Log("Test count initContainers in job")
 	foundInitContainers := len(batchJobObj.Spec.Template.Spec.InitContainers)
 
-	if foundInitContainers != 4 {
+	if foundInitContainers != 5 {
 		t.Fatalf("Invalid InitContainers count, expected %v found %v\n",
 			numInitContainers, foundInitContainers)
 	}

--- a/pkg/jobs/importer/managedcluster.go
+++ b/pkg/jobs/importer/managedcluster.go
@@ -11,6 +11,8 @@ import (
 	managedclusterv1 "github.com/open-cluster-management/api/cluster/v1"
 	"github.com/open-cluster-management/cluster-curator-controller/pkg/jobs/utils"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
 )
 
@@ -53,4 +55,52 @@ func MonitorImport(mcset managedclusterclient.Interface, clusterName string) err
 		}
 		time.Sleep(utils.PauseTenSeconds)
 	}
+}
+
+const retryCount = 150
+
+func MonitorMCInfoImport(mcset dynamic.Interface, clusterName string) error {
+
+	var mciGVR = schema.GroupVersionResource{
+		Group: "internal.open-cluster-management.io", Version: "v1beta1", Resource: "managedclusterinfos"}
+	klog.V(0).Info("=> Monitoring ManagedClusterInfos import of \"" + clusterName +
+		"\" using Override Template \"" + clusterName + "\"")
+
+	/* Two levels of status.conditions:
+	 * managedClusterAvailable
+	 * ManagedClusterJoined
+	 *
+	 * Order is important. We expect the default for a few tries, then ManagedCluster joined
+	 * and finally exit when available
+	 */
+	// TODO: Add a timeout after 60min, make configurable
+	for i := 1; i <= retryCount; i++ {
+		managedCluster, err := mcset.Resource(mciGVR).Namespace(clusterName).Get(context.TODO(), clusterName, v1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if managedCluster.Object["status"].(map[string]interface{})["conditions"] != nil {
+			for _, condition := range managedCluster.Object["status"].(map[string]interface{})["conditions"].([]interface{}) {
+				switch condition.(map[string]interface{})["type"] {
+
+				case managedclusterv1.ManagedClusterConditionHubDenied:
+					return errors.New("ManagedCluster join denied")
+
+				case managedclusterv1.ManagedClusterConditionAvailable:
+					klog.V(2).Info("ManagedCluster available")
+					return nil
+
+				case managedclusterv1.ManagedClusterConditionJoined:
+					klog.V(2).Infof("ManagedCluster joined but not avaialble (%v/%v)", i, retryCount)
+
+				default:
+					klog.V(2).Infof("Waiting for ManagedCluster to join %v (%v/%v)", condition.(map[string]interface{})["message"], i, retryCount)
+				}
+			}
+		} else {
+			klog.V(2).Infof("Waiting for %v ManagedCluster to report conditions (%v/%v)", clusterName, i, retryCount)
+		}
+		time.Sleep(utils.PauseTwoSeconds)
+	}
+	return errors.New("Time out waiting for cluster to import")
 }

--- a/pkg/jobs/importer/managedcluster_test.go
+++ b/pkg/jobs/importer/managedcluster_test.go
@@ -2,12 +2,19 @@
 package importer
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/open-cluster-management/api/client/cluster/clientset/versioned/fake"
 	managedclusterv1 "github.com/open-cluster-management/api/cluster/v1"
+	"github.com/open-cluster-management/cluster-curator-controller/pkg/jobs/utils"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynfake "k8s.io/client-go/dynamic/fake"
 )
 
 const ClusterName = "my-cluster"
@@ -66,4 +73,85 @@ func TestMonitorManagedClusterConditionDenied(t *testing.T) {
 	})
 
 	assert.NotNil(t, MonitorImport(mcset, ClusterName), "err not nil, when ManagedCluster join condition is denied")
+}
+
+func getManagedClusterInfos(conditionType string, conditionMessage string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "internal.open-cluster-management.io/v1beta1",
+			"kind":       "ManagedClusterInfo",
+			"metadata": map[string]interface{}{
+				"name":      ClusterName,
+				"namespace": ClusterName,
+			},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":    conditionType,
+						"message": conditionMessage,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestMonitorMCInfoConditionMissingManagedClusterInfos(t *testing.T) {
+
+	//s.AddKnownTypes(ajv1.SchemeBuilder.GroupVersion, &ajv1.AnsibleJob{}, &corev1.ConfigMap{})
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+	assert.NotNil(t, MonitorMCInfoImport(dynfake, ClusterName), "err not nil, when ManagedClusterInfo resource is not present")
+}
+func TestMonitorMCInfoConditionAvailable(t *testing.T) {
+
+	//s.AddKnownTypes(ajv1.SchemeBuilder.GroupVersion, &ajv1.AnsibleJob{}, &corev1.ConfigMap{})
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), getManagedClusterInfos(managedclusterv1.ManagedClusterConditionAvailable, "All good"))
+	assert.Nil(t, MonitorMCInfoImport(dynfake, ClusterName), "err nil, when ManagedClusterInfos is available")
+}
+
+func TestMonitorMCInfoConditionDenied(t *testing.T) {
+
+	//s.AddKnownTypes(ajv1.SchemeBuilder.GroupVersion, &ajv1.AnsibleJob{}, &corev1.ConfigMap{})
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), getManagedClusterInfos(managedclusterv1.ManagedClusterConditionHubDenied, "Not Allowed"))
+	assert.NotNil(t, MonitorMCInfoImport(dynfake, ClusterName), "err not nil, when ManagedClusterInfos is denied")
+}
+
+var mciGVR = schema.GroupVersionResource{
+	Group: "internal.open-cluster-management.io", Version: "v1beta1", Resource: "managedclusterinfos"}
+
+func TestMonitorMCInfoConditionFullFlowAvailable(t *testing.T) {
+
+	//s.AddKnownTypes(ajv1.SchemeBuilder.GroupVersion, &ajv1.AnsibleJob{}, &corev1.ConfigMap{})
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), getManagedClusterInfos("", ""))
+	go func() {
+
+		time.Sleep(utils.PauseFiveSeconds)
+		_, err := dynfake.Resource(mciGVR).Namespace(ClusterName).Update(context.TODO(), getManagedClusterInfos(managedclusterv1.ManagedClusterConditionJoined, "Cluster has joined."), v1.UpdateOptions{})
+		assert.Nil(t, err, "err is nill, when ManagedClusterConditionJoined condition is created")
+
+		time.Sleep(utils.PauseFiveSeconds)
+		_, err = dynfake.Resource(mciGVR).Namespace(ClusterName).Update(context.TODO(), getManagedClusterInfos(managedclusterv1.ManagedClusterConditionAvailable, "connected"), v1.UpdateOptions{})
+		assert.Nil(t, err, "err is nill, when ManagedClusterConditionAvailable condition is updated")
+	}()
+	assert.Nil(t, MonitorMCInfoImport(dynfake, ClusterName), "err nil, when ManagedCluster is available")
+}
+
+// Includes a test for no-initial conditions
+func TestMonitorMCInfoConditionFullFlowDenied(t *testing.T) {
+
+	mci := getManagedClusterInfos("", "")
+	mci.Object["status"].(map[string]interface{})["conditions"] = nil
+	//s.AddKnownTypes(ajv1.SchemeBuilder.GroupVersion, &ajv1.AnsibleJob{}, &corev1.ConfigMap{})
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), mci)
+	go func() {
+
+		time.Sleep(utils.PauseFiveSeconds)
+		_, err := dynfake.Resource(mciGVR).Namespace(ClusterName).Update(context.TODO(), getManagedClusterInfos(managedclusterv1.ManagedClusterConditionJoined, "Cluster has joined."), v1.UpdateOptions{})
+		assert.Nil(t, err, "err is nill, when ManagedClusterConditionJoined condition is created")
+
+		time.Sleep(utils.PauseFiveSeconds)
+		_, err = dynfake.Resource(mciGVR).Namespace(ClusterName).Update(context.TODO(), getManagedClusterInfos(managedclusterv1.ManagedClusterConditionHubDenied, "connected"), v1.UpdateOptions{})
+		assert.Nil(t, err, "err is nill, when ManagedClusterConditionAvailable condition is updated")
+	}()
+	assert.NotNil(t, MonitorMCInfoImport(dynfake, ClusterName), "err not nil, when ManagedCluster is denied")
 }

--- a/pkg/jobs/rbac/rbac_test.go
+++ b/pkg/jobs/rbac/rbac_test.go
@@ -4,7 +4,9 @@ package rbac
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/open-cluster-management/cluster-curator-controller/pkg/jobs/utils"
 	"github.com/stretchr/testify/assert"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,17 +15,16 @@ import (
 
 const ClusterName = "my-cluster"
 
-func TestApplyRbac(t *testing.T) {
-
-	rules := []rbacv1.PolicyRule{
+func getRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
 		rbacv1.PolicyRule{
-			APIGroups: []string{"tower.ansible.com", "", "hive.openshift.io"},
-			Resources: []string{"ansiblejobs", "secrets", "clusterdeployments", "machinepools"},
+			APIGroups: []string{"tower.ansible.com", ""},
+			Resources: []string{"ansiblejobs", "secrets", "serviceaccounts"},
 			Verbs:     []string{"create"},
 		},
 		rbacv1.PolicyRule{
-			APIGroups: []string{"", "hive.openshift.io"},
-			Resources: []string{"clusterdeployments", "secrets"},
+			APIGroups: []string{"hive.openshift.io"},
+			Resources: []string{"clusterdeployments"},
 			Verbs:     []string{"patch"},
 		},
 		rbacv1.PolicyRule{
@@ -36,12 +37,45 @@ func TestApplyRbac(t *testing.T) {
 			Resources: []string{"configmaps"},
 			Verbs:     []string{"update", "get", "patch"},
 		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"internal.open-cluster-management.io"},
+			Resources: []string{"managedclusterinfos"},
+			Verbs:     []string{"get"},
+		},
 	}
+}
+
+func getCombinedCIRules() []rbacv1.PolicyRule {
+	return append(getRules(),
+		[]rbacv1.PolicyRule{
+			rbacv1.PolicyRule{
+				APIGroups: []string{"tower.ansible.com"},
+				Resources: []string{"ansiblejobs"},
+				Verbs:     []string{"create", "get"},
+			},
+			rbacv1.PolicyRule{
+				APIGroups: []string{"batch"},
+				Resources: []string{"jobs"},
+				Verbs:     []string{"get"},
+			},
+			rbacv1.PolicyRule{
+				APIGroups: []string{"", "hive.openshift.io"},
+				Resources: []string{"configmaps", "clusterdeployments"},
+				Verbs:     []string{"patch"},
+			},
+			rbacv1.PolicyRule{
+				APIGroups: []string{"internal.open-cluster-management.io"},
+				Resources: []string{"managedclusterinfos"},
+				Verbs:     []string{"get"},
+			},
+		}...)
+}
+func TestApplyRbac(t *testing.T) {
 
 	subjects := []rbacv1.Subject{
 		rbacv1.Subject{
 			Kind:      "ServiceAccount",
-			Name:      clusterInstall,
+			Name:      clusterInstaller,
 			Namespace: ClusterName,
 		},
 	}
@@ -59,7 +93,7 @@ func TestApplyRbac(t *testing.T) {
 
 	t.Log("Validate ServiceaAccount")
 
-	_, err = kubeset.CoreV1().ServiceAccounts(ClusterName).Get(context.TODO(), clusterInstall, v1.GetOptions{})
+	_, err = kubeset.CoreV1().ServiceAccounts(ClusterName).Get(context.TODO(), clusterInstaller, v1.GetOptions{})
 	assert.Nil(t, err, "err nil, when service account exists")
 
 	t.Log("Validate Role")
@@ -67,7 +101,7 @@ func TestApplyRbac(t *testing.T) {
 	role, err := kubeset.RbacV1().Roles(ClusterName).Get(context.TODO(), "curator", v1.GetOptions{})
 
 	assert.Nil(t, err, "err nil, when Role exists")
-	assert.ElementsMatch(t, rules, role.Rules, "The rules should match")
+	assert.ElementsMatch(t, getRules(), role.Rules, "The rules should match")
 
 	t.Log("Validate RoleBinding")
 	roleBinding, err := kubeset.RbacV1().RoleBindings(ClusterName).
@@ -84,4 +118,41 @@ func TestApplyRbac(t *testing.T) {
 		return false
 	}, "roleRef must match,\nExpected: %v\nFound: %v", &roleRef, &roleBinding.RoleRef)
 	assert.ElementsMatch(t, subjects, roleBinding.Subjects, "subjects must match")
+}
+
+func TestExtendClusterInstallerRole(t *testing.T) {
+
+	kubeset := fake.NewSimpleClientset()
+
+	testRole := getRole()
+	testRole.Name = clusterInstaller
+
+	// Delay 5s so that we can see the ExtendClusterInstallerRole wait
+	go func() {
+		time.Sleep(utils.PauseFiveSeconds)
+		_, err := kubeset.RbacV1().Roles(ClusterName).Create(context.TODO(), testRole, v1.CreateOptions{})
+		assert.Nil(t, err, "err is nil, when cluster-installer role is created")
+	}()
+
+	err := ExtendClusterInstallerRole(kubeset, ClusterName)
+	assert.Nil(t, err, "err is nil, when cluster-installer role is extended")
+
+	role, err := kubeset.RbacV1().Roles(ClusterName).Get(context.TODO(), clusterInstaller, v1.GetOptions{})
+	assert.Nil(t, err, "err is nil when role is found")
+
+	assert.ElementsMatch(t, role.Rules, getCombinedCIRules(), "Rules should be equal")
+}
+
+func TestExtendClusterInstallerRoleTimeout(t *testing.T) {
+
+	kubeset := fake.NewSimpleClientset()
+
+	testRole := getRole()
+	testRole.Name = clusterInstaller
+
+	err := ExtendClusterInstallerRole(kubeset, ClusterName)
+
+	assert.NotNil(t, err, "err not nil, when failure or timeout")
+	t.Log(err.Error())
+	assert.Contains(t, err.Error(), "Timeout waiting for role", "err.Error() should contain \"Timeout waiting for role\"")
 }

--- a/pkg/jobs/utils/helpers.go
+++ b/pkg/jobs/utils/helpers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,7 +20,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const PauseTenSeconds = 10 * time.Second
+const PauseTwoSeconds = 2 * time.Second
+const PauseTenSeconds = PauseTwoSeconds * 5
 const PauseFiveSeconds = PauseTenSeconds / 2
 const CurrentAnsibleJob = "active-ansible-job"
 const CurrentHiveJob = "hive-provisioning-job"
@@ -32,9 +34,12 @@ type PatchStringValue struct {
 	Value string `json:"value"`
 }
 
-func InitKlog() {
+const LogVerbosity = 2
+
+func InitKlog(logLevel int) {
 
 	klog.InitFlags(nil)
+	flag.Set("v", strconv.Itoa(logLevel))
 	flag.Parse()
 
 }

--- a/pkg/jobs/utils/helpers_test.go
+++ b/pkg/jobs/utils/helpers_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestCheckErrorNil(t *testing.T) {
 
-	InitKlog()
+	InitKlog(4)
 	assert.NotPanics(t, func() { CheckError(nil) }, "No panic, when err is not present")
 }
 


### PR DESCRIPTION
Signed off by: @jnpacker 

* Add support to monitor ManagedClusterInfos - Instead of ManagedCluster, this saves a RoleBinding resource
* Added extend cluster-installer role (not used as Hive controller overwrites this role periodically)
* Added flag.set so that verbose level 2 is now available
* End to end deployment validated
* Add TTL for the curator-job pod