### PR TITLE
Fix leader election rules.

### DIFF
--- a/deploy/controller/clusterrole.yaml
+++ b/deploy/controller/clusterrole.yaml
@@ -6,6 +6,7 @@ metadata:
 rules:
 
 # New Rules added to ClusterInstaller
+# Leader Lock requires configmaps(create&get) and pods(get)
 - apiGroups: ["tower.ansible.com","batch",""]
   resources: ["ansiblejobs","jobs","serviceaccounts","configmaps"]
   verbs: ["create","get"]

--- a/deploy/controller/clusterrole.yaml
+++ b/deploy/controller/clusterrole.yaml
@@ -7,7 +7,7 @@ rules:
 
 # New Rules added to ClusterInstaller
 - apiGroups: ["tower.ansible.com","batch",""]
-  resources: ["ansiblejobs","jobs","serviceaccounts",]
+  resources: ["ansiblejobs","jobs","serviceaccounts","configmaps"]
   verbs: ["create","get"]
 
 - apiGroups: ["rbac.authorization.k8s.io"]
@@ -18,8 +18,8 @@ rules:
   resources: ["configmaps", "clusterdeployments"]
   verbs: ["patch"]
 
-- apiGroups: ["internal.open-cluster-management.io"]
-  resources: ["managedclusterinfos"]
+- apiGroups: ["internal.open-cluster-management.io",""]
+  resources: ["managedclusterinfos","pods"]
   verbs: ["get"]
 
 # Specific to the controller only


### PR DESCRIPTION
Signed off by @jnpacker 

* Missing rules in cluster-curator clusterRole that keep the pods from coming online.

```
configmaps: create, get
pods:           get
```

## Issue reference:
https://github.com/open-cluster-management/backlog/issues/10674

## Original errors:
### Create configmaps:
```bash
E0319 13:27:15.074157       1 controller.go:128] configmaps is forbidden: User "system:serviceaccount:open-cluster-management:cluster-curator" cannot create resource "configmaps" in API group "" in the namespace "open-cluster-management": RBAC: clusterrole.rbac.authorization.k8s.io "open-cluster-management.cluster-lifecycle.cluster-curator" not foundDid not obtain leader cluster-curator-controller-lock
```

## Get configmaps:
```bash
E0319 13:25:15.583227       1 controller.go:128] configmaps "cluster-curator-controller-lock" is forbidden: User "system:serviceaccount:open-cluster-management:cluster-curator" cannot get resource "configmaps" in API group "" in the namespace "open-cluster-management": RBAC: clusterrole.rbac.authorization.k8s.io "open-cluster-management.cluster-lifecycle.cluster-curator" not foundDid not obtain leader cluster-curator-controller-lock
```

## Get pods:
```bash
E0319 13:23:32.483700       1 controller.go:128] pods "cluster-curator-controller-7fdd56984b-8fhtc" is forbidden: User "system:serviceaccount:open-cluster-management:cluster-curator" cannot get resource "pods" in API group "" in the namespace "open-cluster-management": RBAC: clusterrole.rbac.authorization.k8s.io "open-cluster-management.cluster-lifecycle.cluster-curator" not foundDid not obtain leader cluster-curator-controller-lock
```

/cc @chrisahl 