### PR TITLE
Increase the timeout when looking for the hive provisioning job to 3min

### DIFF
--- a/pkg/jobs/hive/hive.go
+++ b/pkg/jobs/hive/hive.go
@@ -78,12 +78,12 @@ func MonitorDeployStatus(config *rest.Config, clusterName string) error {
 	if err = utils.LogError(err); err != nil {
 		return err
 	}
-	return monitorDeployStatus(client, hiveset, clusterName, 4) // 4min timeout for Hive job to start
+	return monitorDeployStatus(client, hiveset, clusterName, ThreeMinuteMonitorTimeout)
 }
 
 func monitorDeployStatus(client clientv1.Client, hiveset hiveclient.Interface, clusterName string, monitorAttempts int) error {
 
-	klog.V(0).Info("Waiting up to " + strconv.Itoa(ThreeMinuteMonitorTimeout*5) + "s for Hive Provisioning job")
+	klog.V(0).Info("Waiting up to " + strconv.Itoa(monitorAttempts*5) + "s for Hive Provisioning job")
 	jobName := ""
 
 	for i := 1; i <= monitorAttempts; i++ {

--- a/pkg/jobs/hive/hive.go
+++ b/pkg/jobs/hive/hive.go
@@ -34,9 +34,9 @@ type patchStringValue struct {
 	Value int32  `json:"value"`
 }
 
-const MonitorAttempts = 6
 const UpgradeAttempts = 120
 const MCVUpgradeLabel = "cluster-curator-upgrade"
+const ThreeMinuteMonitorTimeout = 36
 
 func ActivateDeploy(hiveset hiveclient.Interface, clusterName string) error {
 	klog.V(0).Info("* Initiate Provisioning")
@@ -78,15 +78,15 @@ func MonitorDeployStatus(config *rest.Config, clusterName string) error {
 	if err = utils.LogError(err); err != nil {
 		return err
 	}
-	return monitorDeployStatus(client, hiveset, clusterName)
+	return monitorDeployStatus(client, hiveset, clusterName, 4) // 4min timeout for Hive job to start
 }
 
-func monitorDeployStatus(client clientv1.Client, hiveset hiveclient.Interface, clusterName string) error {
+func monitorDeployStatus(client clientv1.Client, hiveset hiveclient.Interface, clusterName string, monitorAttempts int) error {
 
-	klog.V(0).Info("Waiting up to 30s for Hive Provisioning job")
+	klog.V(0).Info("Waiting up to " + strconv.Itoa(ThreeMinuteMonitorTimeout*5) + "s for Hive Provisioning job")
 	jobName := ""
 
-	for i := 1; i <= MonitorAttempts; i++ { // 30s wait
+	for i := 1; i <= monitorAttempts; i++ {
 
 		// Refresh the clusterDeployment resource
 		cluster, err := hiveset.HiveV1().ClusterDeployments(clusterName).Get(
@@ -170,7 +170,7 @@ func monitorDeployStatus(client clientv1.Client, hiveset hiveclient.Interface, c
 			// Detect that we've failed
 		} else {
 
-			klog.V(0).Infof("Attempt: "+strconv.Itoa(i)+"/%v, pause %v", MonitorAttempts, utils.PauseFiveSeconds)
+			klog.V(0).Infof("Attempt: "+strconv.Itoa(i)+"/%v, pause %v", monitorAttempts, utils.PauseFiveSeconds)
 			time.Sleep(utils.PauseFiveSeconds)
 
 			for _, condition := range cluster.Status.Conditions {
@@ -180,7 +180,7 @@ func monitorDeployStatus(client clientv1.Client, hiveset hiveclient.Interface, c
 					return errors.New("Failure detected")
 				}
 			}
-			if i == MonitorAttempts {
+			if i == monitorAttempts {
 				klog.Warning(cluster.Status.Conditions)
 				return errors.New("Timed out waiting for job")
 			}

--- a/pkg/jobs/hive/hive_test.go
+++ b/pkg/jobs/hive/hive_test.go
@@ -241,7 +241,7 @@ func TestMonitorDeployStatusCondition(t *testing.T) {
 
 	hiveset := hivefake.NewSimpleClientset(cd)
 
-	assert.NotNil(t, monitorDeployStatus(nil, hiveset, ClusterName, 1), "err is not nil, when cluster provisioning has a condition")
+	assert.NotNil(t, monitorDeployStatus(nil, hiveset, ClusterName, testTimeout), "err is not nil, when cluster provisioning has a condition")
 }
 
 func TestMonitorDeployNoJobTimeout(t *testing.T) {

--- a/pkg/jobs/hive/hive_test.go
+++ b/pkg/jobs/hive/hive_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 const ClusterName = "my-cluster"
+const testTimeout = 6
 
 func getClusterCurator() *clustercuratorv1.ClusterCurator {
 	return &clustercuratorv1.ClusterCurator{
@@ -224,7 +225,7 @@ func TestMonitorDeployStatusNoClusterDeployment(t *testing.T) {
 
 	hiveset := hivefake.NewSimpleClientset()
 
-	assert.NotNil(t, monitorDeployStatus(nil, hiveset, ClusterName), "err is not nil, when cluster provisioning has a condition")
+	assert.NotNil(t, monitorDeployStatus(nil, hiveset, ClusterName, testTimeout), "err is not nil, when cluster provisioning has a condition")
 }
 
 func TestMonitorDeployStatusCondition(t *testing.T) {
@@ -240,7 +241,7 @@ func TestMonitorDeployStatusCondition(t *testing.T) {
 
 	hiveset := hivefake.NewSimpleClientset(cd)
 
-	assert.NotNil(t, monitorDeployStatus(nil, hiveset, ClusterName), "err is not nil, when cluster provisioning has a condition")
+	assert.NotNil(t, monitorDeployStatus(nil, hiveset, ClusterName, 1), "err is not nil, when cluster provisioning has a condition")
 }
 
 func TestMonitorDeployNoJobTimeout(t *testing.T) {
@@ -249,7 +250,7 @@ func TestMonitorDeployNoJobTimeout(t *testing.T) {
 
 	hiveset := hivefake.NewSimpleClientset(cd)
 
-	assert.NotNil(t, monitorDeployStatus(nil, hiveset, ClusterName), "err is not nil, when cluster provisioning has no job created")
+	assert.NotNil(t, monitorDeployStatus(nil, hiveset, ClusterName, 2), "err is not nil, when cluster provisioning has no job created")
 }
 func TestMonitorDeployStatusJobFailed(t *testing.T) {
 
@@ -270,7 +271,7 @@ func TestMonitorDeployStatusJobFailed(t *testing.T) {
 
 	client := clientfake.NewFakeClientWithScheme(s, cc, job)
 
-	assert.NotNil(t, monitorDeployStatus(client, hiveset, ClusterName), "err is not nil, when cluster provisioning has a condition")
+	assert.NotNil(t, monitorDeployStatus(client, hiveset, ClusterName, testTimeout), "err is not nil, when cluster provisioning has a condition")
 }
 
 func TestMonitorDeployStatusJobCompletedWithSuccess(t *testing.T) {
@@ -303,7 +304,7 @@ func TestMonitorDeployStatusJobCompletedWithSuccess(t *testing.T) {
 	}()
 
 	assert.Equal(t, len(cc.Status.Conditions), 0, "Should be emtpy")
-	assert.Nil(t, monitorDeployStatus(client, hiveset, ClusterName), "err is nil, when cluster provisioning is successful")
+	assert.Nil(t, monitorDeployStatus(client, hiveset, ClusterName, testTimeout), "err is nil, when cluster provisioning is successful")
 
 	err := client.Get(context.Background(), types.NamespacedName{Namespace: ClusterName, Name: ClusterName}, cc)
 	t.Log(err)
@@ -344,7 +345,7 @@ func TestMonitorDeployStatusJobComplete(t *testing.T) {
 		hiveset.HiveV1().ClusterDeployments(ClusterName).Update(context.TODO(), cd, v1.UpdateOptions{})
 	}()
 
-	assert.Nil(t, monitorDeployStatus(client, hiveset, ClusterName), "err is not nil, when cluster provisioning is successful")
+	assert.Nil(t, monitorDeployStatus(client, hiveset, ClusterName, testTimeout), "err is not nil, when cluster provisioning is successful")
 }
 
 func TestMonitorDeployStatusJobDelayedComplete(t *testing.T) {
@@ -374,7 +375,7 @@ func TestMonitorDeployStatusJobDelayedComplete(t *testing.T) {
 		hiveset.HiveV1().ClusterDeployments(ClusterName).Update(context.TODO(), cd, v1.UpdateOptions{})
 	}()
 
-	assert.Nil(t, monitorDeployStatus(client, hiveset, ClusterName), "err is not nil, when cluster provisioning is successful")
+	assert.Nil(t, monitorDeployStatus(client, hiveset, ClusterName, testTimeout), "err is not nil, when cluster provisioning is successful")
 }
 
 func TestUpgradeClusterNonOpenshift(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

* Push the timeout up to 3min from 30s.