### PR TITLE
Destroy curation

### DIFF
--- a/controllers/clustercurator_controller.go
+++ b/controllers/clustercurator_controller.go
@@ -46,7 +46,7 @@ func (r *ClusterCuratorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	if curator.Spec.DesiredCuration == DeleteNamespace {
 		log.V(0).Info("Deleting namespace " + curator.Namespace)
-		err := utils.DeleteNamespace(curator.Namespace)
+		err := utils.DeleteClusterNamespace(r.Kubeset, curator.Namespace)
 
 		if err != nil {
 			log.V(0).Info(" Deleted namespace ✓ " + curator.Namespace)

--- a/deploy/controller/clusterrole.yaml
+++ b/deploy/controller/clusterrole.yaml
@@ -21,7 +21,7 @@ rules:
 
 - apiGroups: ["hive.openshift.io"]
   resources: ["clusterdeployments"]
-  verbs: ["patch"]
+  verbs: ["patch","delete"]
 
 - apiGroups: ["internal.open-cluster-management.io",""]
   resources: ["managedclusterinfos","pods"]
@@ -30,6 +30,14 @@ rules:
 # Specific to the controller only
 - apiGroups: ["cluster.open-cluster-management.io"] 
   resources: ["managedclusters"]
+  verbs: ["list"]
+
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["delete"]
+
+- apiGroups: [""]
+  resources: ["pods"]
   verbs: ["list"]
 
 # ClusterCurator apiGroup

--- a/deploy/crd/cluster.open-cluster-management.io_clustercurators.yaml
+++ b/deploy/crd/cluster.open-cluster-management.io_clustercurators.yaml
@@ -42,6 +42,7 @@ spec:
                 - scale
                 - upgrade
                 - destroy
+                - delete-cluster-namespace
                 type: string
               destroy:
                 description: During an destroy curation run these **Pre hook ONLY**

--- a/pkg/api/v1beta1/clustercurator_types.go
+++ b/pkg/api/v1beta1/clustercurator_types.go
@@ -15,7 +15,7 @@ type ClusterCuratorSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// This is the desired curation that will occur
-	// +kubebuilder:validation:Enum={install,scale,upgrade,destroy}
+	// +kubebuilder:validation:Enum={install,scale,upgrade,destroy,delete-cluster-namespace}
 	DesiredCuration string `json:"desiredCuration,omitempty"`
 
 	// Points to the Cloud Provider or Ansible Provider secret, format: namespace/secretName

--- a/pkg/jobs/hive/hive.go
+++ b/pkg/jobs/hive/hive.go
@@ -69,7 +69,7 @@ func ActivateDeploy(hiveset hiveclient.Interface, clusterName string) error {
 	return nil
 }
 
-func MonitorDeployStatus(config *rest.Config, clusterName string) error {
+func MonitorClusterStatus(config *rest.Config, clusterName string, jobType string) error {
 	hiveset, err := hiveclient.NewForConfig(config)
 	if err = utils.LogError(err); err != nil {
 		return err
@@ -78,13 +78,34 @@ func MonitorDeployStatus(config *rest.Config, clusterName string) error {
 	if err = utils.LogError(err); err != nil {
 		return err
 	}
-	return monitorDeployStatus(client, hiveset, clusterName)
+	return monitorClusterStatus(client, hiveset, clusterName, jobType)
 }
 
-func monitorDeployStatus(client clientv1.Client, hiveset hiveclient.Interface, clusterName string) error {
+func DestroyClusterDeployment(hiveset hiveclient.Interface, clusterName string) error {
+	klog.V(0).Infof("Deleting Cluster Deployment for %v\n", clusterName)
 
-	klog.V(0).Info("Waiting up to 30s for Hive Provisioning job")
+	cluster, err := hiveset.HiveV1().ClusterDeployments(clusterName).Get(
+		context.TODO(), clusterName, v1.GetOptions{})
+
+	if err != nil {
+		klog.Warning("Could not retreive cluster " + clusterName + " may have already been deleted")
+		return nil
+	}
+
+	err = hiveset.HiveV1().ClusterDeployments(clusterName).Delete(context.Background(), cluster.Name, v1.DeleteOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func monitorClusterStatus(client clientv1.Client, hiveset hiveclient.Interface, clusterName string, jobType string) error {
+
+	klog.V(0).Info("Waiting up to 3min for Hive " + jobType + "ing job")
 	jobName := ""
+	var cluster *hivev1.ClusterDeployment
 
 	for i := 1; i <= MonitorAttempts; i++ { // 30s wait
 
@@ -93,10 +114,16 @@ func monitorDeployStatus(client clientv1.Client, hiveset hiveclient.Interface, c
 			context.TODO(), clusterName, v1.GetOptions{})
 
 		if err = utils.LogError(err); err != nil {
+
+			// If the cluster deployment is already gone
+			if jobType == utils.Destroying {
+				klog.Warning("No cluster deployment for " + clusterName + " was found")
+				return nil
+			}
 			return err
 		}
 
-		if cluster.Status.WebConsoleURL != "" {
+		if jobType == utils.Installing && cluster.Status.WebConsoleURL != "" {
 			klog.V(2).Info("Provisioning succeeded ✓")
 
 			if jobName != "" {
@@ -108,22 +135,29 @@ func monitorDeployStatus(client clientv1.Client, hiveset hiveclient.Interface, c
 					jobName))
 			}
 
-			break
-		} else if cluster.Status.ProvisionRef != nil &&
-			cluster.Status.ProvisionRef.Name != "" {
+			return nil
+
+		} else if (cluster.Status.ProvisionRef != nil &&
+			cluster.Status.ProvisionRef.Name != "") || jobType == utils.Destroying {
 
 			klog.V(2).Info("Found ClusterDeployment status details ✓")
-			jobName = cluster.Status.ProvisionRef.Name + "-provision"
+
+			if jobType == utils.Destroying {
+				jobName = clusterName + "-" + utils.Destroying
+			} else {
+				jobName = cluster.Status.ProvisionRef.Name + "-provision"
+			}
+
 			jobPath := clusterName + "/" + jobName
 
-			klog.V(2).Info("Checking for provisioning job " + jobPath)
+			klog.V(2).Info("Checking for " + jobType + "ing job " + jobPath)
 			newJob := &batchv1.Job{}
 			err := client.Get(context.Background(), types.NamespacedName{Namespace: clusterName, Name: jobName}, newJob)
 
-			// If the job is missing follow the main loop 5min Pause
+			// If the job is missing, follow the main loop
 			if err != nil && strings.Contains(err.Error(), " not found") {
 				klog.Warningf("Could not retrieve job: %v", err)
-				time.Sleep(utils.PauseTenSeconds) //10s
+				time.Sleep(utils.PauseFiveSeconds) //10s
 				continue
 			}
 
@@ -135,12 +169,12 @@ func monitorDeployStatus(client clientv1.Client, hiveset hiveclient.Interface, c
 			elapsedTime := 0
 
 			// Wait while the job is running
-			klog.V(0).Info("Wait for the provisioning job in Hive to complete")
+			klog.V(0).Info("Wait for the " + jobType + "ing job from Hive to complete")
 
 			utils.CheckError(utils.RecordCurrentStatusCondition(
 				client,
 				clusterName,
-				"hive-provisioning-job",
+				"hive-"+jobType+"ing-job",
 				v1.ConditionFalse,
 				jobName))
 
@@ -153,20 +187,39 @@ func monitorDeployStatus(client clientv1.Client, hiveset hiveclient.Interface, c
 
 				// Reset the job, so we make sure we're getting clean data (not cached)
 				newJob = &batchv1.Job{}
-				utils.CheckError(client.Get(
+				err = client.Get(
 					context.Background(),
 					types.NamespacedName{Namespace: clusterName, Name: jobName},
-					newJob))
+					newJob)
+
+				if jobType == utils.Destroying && err != nil && strings.Contains(err.Error(), " not found") {
+					break
+				}
+
+				utils.CheckError(err)
+			}
+
+			// When Destroying, by this point the job finished
+			if jobType == utils.Destroying {
+				klog.V(0).Info("Uninstall job complete")
+				utils.CheckError(utils.RecordCurrentStatusCondition(
+					client,
+					clusterName,
+					"hive-"+jobType+"ing-job",
+					v1.ConditionTrue,
+					jobName))
+				return nil
 			}
 
 			// If succeeded = 0 then we did not finish
 			if newJob.Status.Succeeded == 0 {
 				cluster, err = hiveset.HiveV1().ClusterDeployments(clusterName).Get(context.TODO(), clusterName, v1.GetOptions{})
 				klog.Warning(cluster.Status.Conditions)
-				return errors.New("Provisioning job \"" + jobPath + "\" failed")
+				return errors.New(jobType + "ing job \"" + jobPath + "\" failed")
 			}
 
-			klog.V(0).Info("The provisioning job in Hive completed ✓")
+			klog.V(0).Info("The " + jobType + "ing job from Hive completed ✓")
+
 			// Detect that we've failed
 		} else {
 
@@ -180,13 +233,12 @@ func monitorDeployStatus(client clientv1.Client, hiveset hiveclient.Interface, c
 					return errors.New("Failure detected")
 				}
 			}
-			if i == MonitorAttempts {
-				klog.Warning(cluster.Status.Conditions)
-				return errors.New("Timed out waiting for job")
-			}
 		}
 	}
-	return nil
+	if cluster != nil {
+		klog.Warning(cluster.Status.Conditions)
+	}
+	return errors.New("Timed out waiting for job")
 }
 
 func UpgradeCluster(client clientv1.Client, clusterName string, curator *clustercuratorv1.ClusterCurator) error {

--- a/pkg/jobs/hive/hive_test.go
+++ b/pkg/jobs/hive/hive_test.go
@@ -224,7 +224,8 @@ func TestMonitorDeployStatusNoClusterDeployment(t *testing.T) {
 
 	hiveset := hivefake.NewSimpleClientset()
 
-	assert.NotNil(t, monitorDeployStatus(nil, hiveset, ClusterName), "err is not nil, when cluster provisioning has a condition")
+	assert.NotNil(t, monitorClusterStatus(nil, hiveset, ClusterName, utils.Installing),
+		"err is not nil, when cluster provisioning has a condition")
 }
 
 func TestMonitorDeployStatusCondition(t *testing.T) {
@@ -240,7 +241,8 @@ func TestMonitorDeployStatusCondition(t *testing.T) {
 
 	hiveset := hivefake.NewSimpleClientset(cd)
 
-	assert.NotNil(t, monitorDeployStatus(nil, hiveset, ClusterName), "err is not nil, when cluster provisioning has a condition")
+	assert.NotNil(t, monitorClusterStatus(nil, hiveset, ClusterName, utils.Installing),
+		"err is not nil, when cluster provisioning has a condition")
 }
 
 func TestMonitorDeployNoJobTimeout(t *testing.T) {
@@ -249,7 +251,8 @@ func TestMonitorDeployNoJobTimeout(t *testing.T) {
 
 	hiveset := hivefake.NewSimpleClientset(cd)
 
-	assert.NotNil(t, monitorDeployStatus(nil, hiveset, ClusterName), "err is not nil, when cluster provisioning has no job created")
+	assert.NotNil(t, monitorClusterStatus(nil, hiveset, ClusterName, utils.Installing),
+		"err is not nil, when cluster provisioning has no job created")
 }
 func TestMonitorDeployStatusJobFailed(t *testing.T) {
 
@@ -270,7 +273,8 @@ func TestMonitorDeployStatusJobFailed(t *testing.T) {
 
 	client := clientfake.NewFakeClientWithScheme(s, cc, job)
 
-	assert.NotNil(t, monitorDeployStatus(client, hiveset, ClusterName), "err is not nil, when cluster provisioning has a condition")
+	assert.NotNil(t, monitorClusterStatus(client, hiveset, ClusterName, utils.Installing),
+		"err is not nil, when cluster provisioning has a condition")
 }
 
 func TestMonitorDeployStatusJobCompletedWithSuccess(t *testing.T) {
@@ -303,7 +307,8 @@ func TestMonitorDeployStatusJobCompletedWithSuccess(t *testing.T) {
 	}()
 
 	assert.Equal(t, len(cc.Status.Conditions), 0, "Should be emtpy")
-	assert.Nil(t, monitorDeployStatus(client, hiveset, ClusterName), "err is nil, when cluster provisioning is successful")
+	assert.Nil(t, monitorClusterStatus(client, hiveset, ClusterName, utils.Installing),
+		"err is nil, when cluster provisioning is successful")
 
 	err := client.Get(context.Background(), types.NamespacedName{Namespace: ClusterName, Name: ClusterName}, cc)
 	t.Log(err)
@@ -344,7 +349,8 @@ func TestMonitorDeployStatusJobComplete(t *testing.T) {
 		hiveset.HiveV1().ClusterDeployments(ClusterName).Update(context.TODO(), cd, v1.UpdateOptions{})
 	}()
 
-	assert.Nil(t, monitorDeployStatus(client, hiveset, ClusterName), "err is not nil, when cluster provisioning is successful")
+	assert.Nil(t, monitorClusterStatus(client, hiveset, ClusterName, utils.Installing),
+		"err is not nil, when cluster provisioning is successful")
 }
 
 func TestMonitorDeployStatusJobDelayedComplete(t *testing.T) {
@@ -374,7 +380,8 @@ func TestMonitorDeployStatusJobDelayedComplete(t *testing.T) {
 		hiveset.HiveV1().ClusterDeployments(ClusterName).Update(context.TODO(), cd, v1.UpdateOptions{})
 	}()
 
-	assert.Nil(t, monitorDeployStatus(client, hiveset, ClusterName), "err is not nil, when cluster provisioning is successful")
+	assert.Nil(t, monitorClusterStatus(client, hiveset, ClusterName, utils.Installing),
+		"err is not nil, when cluster provisioning is successful")
 }
 
 func TestUpgradeClusterNonOpenshift(t *testing.T) {

--- a/pkg/jobs/importer/managedcluster.go
+++ b/pkg/jobs/importer/managedcluster.go
@@ -5,12 +5,12 @@ package importer
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 
 	managedclusterclient "github.com/open-cluster-management/api/client/cluster/clientset/versioned"
 	managedclusterv1 "github.com/open-cluster-management/api/cluster/v1"
 	"github.com/open-cluster-management/cluster-curator-controller/pkg/jobs/utils"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -115,7 +115,7 @@ func DetachCluster(mcset dynamic.Interface, clusterName string) error {
 	_, err := mcset.Resource(mcGVR).Get(context.TODO(), clusterName, v1.GetOptions{})
 
 	if err != nil {
-		if strings.Contains(err.Error(), " not found") {
+		if k8serrors.IsNotFound(err) {
 			klog.Warning("Did not find managed cluster " + clusterName)
 			return nil
 		} else {

--- a/pkg/jobs/rbac/rbac.go
+++ b/pkg/jobs/rbac/rbac.go
@@ -29,7 +29,7 @@ func getRole() *rbacv1.Role {
 			rbacv1.PolicyRule{
 				APIGroups: []string{"hive.openshift.io"},
 				Resources: []string{"clusterdeployments"},
-				Verbs:     []string{"patch"},
+				Verbs:     []string{"patch", "delete"},
 			},
 			rbacv1.PolicyRule{
 				APIGroups: []string{"batch", "hive.openshift.io", "tower.ansible.com"},

--- a/pkg/jobs/rbac/rbac_test.go
+++ b/pkg/jobs/rbac/rbac_test.go
@@ -25,7 +25,7 @@ func getRules() []rbacv1.PolicyRule {
 		rbacv1.PolicyRule{
 			APIGroups: []string{"hive.openshift.io"},
 			Resources: []string{"clusterdeployments"},
-			Verbs:     []string{"patch"},
+			Verbs:     []string{"patch", "delete"},
 		},
 		rbacv1.PolicyRule{
 			APIGroups: []string{"batch", "hive.openshift.io", "tower.ansible.com"},

--- a/pkg/jobs/utils/helpers.go
+++ b/pkg/jobs/utils/helpers.go
@@ -272,12 +272,11 @@ func GetClusterCurator(client clientv1.Client, clusterName string) (*clustercura
 	return curator, nil
 }
 
-func DeleteNamespace(clusterName string) error {
-	client, _ := GetKubeset()
+func DeleteClusterNamespace(client kubernetes.Interface, clusterName string) error {
 
 	pods, err := client.CoreV1().Pods(clusterName).List(context.Background(), v1.ListOptions{})
 
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), " not found") {
 		return err
 	}
 

--- a/pkg/jobs/utils/helpers.go
+++ b/pkg/jobs/utils/helpers.go
@@ -24,6 +24,7 @@ import (
 	managedclusterinfov1beta1 "github.com/open-cluster-management/multicloud-operators-foundation/pkg/apis/internal.open-cluster-management.io/v1beta1"
 	managedclusterviewv1beta1 "github.com/open-cluster-management/multicloud-operators-foundation/pkg/apis/view/v1beta1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -276,7 +277,7 @@ func DeleteClusterNamespace(client kubernetes.Interface, clusterName string) err
 
 	pods, err := client.CoreV1().Pods(clusterName).List(context.Background(), v1.ListOptions{})
 
-	if err != nil && !strings.Contains(err.Error(), " not found") {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		return err
 	}
 


### PR DESCRIPTION
Signed off by: @jnpacker <jpacker@redhat.com>

* Add `desiredCuration: destroy`
* Includes tests
* Requires that the user delete the ManageCluster resource as this requires higher elevated priviledge.