### PR TITLE
Replace machinepool with install_config in extra_vars

### DIFF
--- a/build/before-make.sh
+++ b/build/before-make.sh
@@ -3,5 +3,5 @@
 # Copyright (c) 2020 Red Hat, Inc.
 ###############################################################################
 
-ln -sf ../../build/git-hooks/pre-commit .git/hooks/pre-commit
+#ln -sf ../../build/git-hooks/pre-commit .git/hooks/pre-commit
 ln -sf ../../build/git-hooks/commit-msg .git/hooks/commit-msg

--- a/deploy/controller/clusterrole.yaml
+++ b/deploy/controller/clusterrole.yaml
@@ -24,7 +24,7 @@ rules:
   verbs: ["patch","delete"]
 
 - apiGroups: ["internal.open-cluster-management.io",""]
-  resources: ["managedclusterinfos","pods"]
+  resources: ["managedclusterinfos","pods","secrets"]
   verbs: ["get"]
 
 # Specific to the controller only

--- a/pkg/jobs/rbac/rbac.go
+++ b/pkg/jobs/rbac/rbac.go
@@ -17,7 +17,7 @@ import (
 
 const clusterInstaller = "cluster-installer"
 
-func getRole() *rbacv1.Role {
+func getRole(clusterName string) *rbacv1.Role {
 	curatorRole := &rbacv1.Role{
 		ObjectMeta: v1.ObjectMeta{Name: "curator"},
 		Rules: []rbacv1.PolicyRule{
@@ -60,6 +60,13 @@ func getRole() *rbacv1.Role {
 				APIGroups: []string{"action.open-cluster-management.io"},
 				Resources: []string{"managedclusteractions"},
 				Verbs:     []string{"get", "create", "update", "delete"},
+			},
+			//To read the install-config secret
+			rbacv1.PolicyRule{
+				APIGroups:     []string{""},
+				Resources:     []string{"secrets"},
+				Verbs:         []string{"get"},
+				ResourceNames: []string{clusterName + "-install-config"},
 			},
 		},
 	}
@@ -142,7 +149,7 @@ func ApplyRBAC(kubeset kubernetes.Interface, namespace string) error {
 	klog.V(2).Info("Check if Role curator exists")
 	if _, err := kubeset.RbacV1().Roles(namespace).Get(context.TODO(), "curator", v1.GetOptions{}); err != nil {
 		klog.V(2).Info(" Creating Role curator")
-		_, err = kubeset.RbacV1().Roles(namespace).Create(context.TODO(), getRole(), v1.CreateOptions{})
+		_, err = kubeset.RbacV1().Roles(namespace).Create(context.TODO(), getRole(namespace), v1.CreateOptions{})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

* Swap Machinepool for install_config. 
* Choose which install_config keys to include so that we do NOT expose any secret data
* Still requires a change to allow `get` for secrets.