### PR TITLE
remove reference to image with old go version

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,4 +1,3 @@
-#FROM registry.ci.openshift.org/open-cluster-management/builder:go1.15-linux-amd64 AS builder
 FROM registry.ci.openshift.org/open-cluster-management/builder:go1.17-linux as builder
 
 WORKDIR /go/src/github.com/open-cluster-management/cluster-curator-controller


### PR DESCRIPTION
The related issue: https://github.com/open-cluster-management/backlog/issues/15570
Signed-off-by: Yang Le <yangle@redhat.com>